### PR TITLE
Arpa builder looks for *.spec too #42

### DIFF
--- a/moncic/build.py
+++ b/moncic/build.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import itertools
 import logging
 import os
 import shlex
@@ -104,13 +105,13 @@ class ARPA(Builder):
 
         # This is executed as a process in the running system; stdout and
         # stderr are logged
-        spec_glob = "*/SPECS/*.spec"
-        specs = glob.glob(spec_glob)
+        spec_globs = ["*/SPECS/*.spec", "*.spec"]
+        itertools.chain.from_iterable(glob(g) for g in spec_globs)
         if not specs:
-            raise RuntimeError(f"{spec_glob!r} not found")
+            raise RuntimeError(f"Spec file not found")
 
         if len(specs) > 1:
-            raise RuntimeError(f"{len(specs)} .spec files found as {spec_glob!r}")
+            raise RuntimeError(f"{len(specs)} .spec files found")
 
         # Install build dependencies
         run(self.builddep + ["-q", "-y", specs[0]])

--- a/moncic/build.py
+++ b/moncic/build.py
@@ -106,7 +106,8 @@ class ARPA(Builder):
         # This is executed as a process in the running system; stdout and
         # stderr are logged
         spec_globs = ["*/SPECS/*.spec", "*.spec"]
-        itertools.chain.from_iterable(glob(g) for g in spec_globs)
+        spec = list(itertools.chain.from_iterable(glob(g) for g in spec_globs))
+
         if not specs:
             raise RuntimeError(f"Spec file not found")
 

--- a/moncic/build.py
+++ b/moncic/build.py
@@ -105,7 +105,7 @@ class ARPA(Builder):
 
         # This is executed as a process in the running system; stdout and
         # stderr are logged
-        spec_globs = ["*/SPECS/*.spec", "*.spec"]
+        spec_globs = ["fedora/SPECS/*.spec", "*.spec"]
         spec = list(itertools.chain.from_iterable(glob(g) for g in spec_globs))
 
         if not specs:


### PR DESCRIPTION
Questa PR dovrebbe fixare #42: ho visto che il codice era già predisposto per gestire spec nella root dir del sorgente, bastava correggere la parte di ricerca dello spec file.