### PR TITLE
Arpa builder saves RPMS and SRPMS file #53

### DIFF
--- a/moncic/build.py
+++ b/moncic/build.py
@@ -195,6 +195,19 @@ class ARPA(Builder):
 
         return None
 
+    def collect_artifacts(self, container: Container, destdir: str):
+        user = UserConfig.from_sudoer()
+        patterns = (
+            "RPMS/*/*.rpm",
+            "SRPMS/*.rpm",
+        )
+        basedir = os.path.join(container.get_root(), "root/rpmbuild")
+        for pattern in patterns:
+            for file in glob.glob(os.path.join(basedir, pattern)):
+                filename = os.path.basename(file)
+                log.info("Copying %s to %s", filename, destdir)
+                link_or_copy(file, destdir, user=user)
+
 
 class SourceInfo(NamedTuple):
     srcname: str


### PR DESCRIPTION
Ho implementato il salvataggio di tutti i file `*.rpm` presenti nelle directory `RPMS` e `SRPMS`. Copio i file direttamente nella directory di destinazione senza replicare le sottodir in `RPMS` in quanto queste dovrebbero essere ridondanti: ad esempio, in `rpmbuild/RPMS/x86_64` si trovano file con pattern `*.x86_64.rpm`.

Per provarlo, basta eseguire il comando dal branch `issue53`:

```
./monci ci -s fedora36 -b arpa --debug -a /path/to/artifacts .
```