### PR TITLE
Distinguish Builder abstract factory from derived builder creation method

### DIFF
--- a/moncic/build.py
+++ b/moncic/build.py
@@ -62,9 +62,13 @@ class Builder:
         return list(cls.builders.keys())
 
     @classmethod
-    def create(cls, name: str, system: System, srcdir: str) -> "Builder":
+    def create_builder(cls, name: str, system: System, srcdir: str) -> "Builder":
         builder_cls = cls.builders[name.lower()]
         return builder_cls.create(system, srcdir)
+
+    @classmethod
+    def create(cls, system: System, srcdir: str) -> "Builder":
+        raise NotImplementedError(f"The builder {cls} cannot be instantiated")
 
     @classmethod
     def detect(cls, system: System, srcdir: str) -> "Builder":

--- a/moncic/ci.py
+++ b/moncic/ci.py
@@ -158,7 +158,7 @@ class CI(MoncicCommand):
             with images.system(self.args.system) as system:
                 with checkout(system, self.args.repo, branch=self.args.branch) as srcdir:
                     if self.args.build_style:
-                        builder = Builder.create(self.args.build_style, system, srcdir)
+                        builder = Builder.create_builder(self.args.build_style, system, srcdir)
                     else:
                         builder = Builder.detect(system, srcdir)
                     log.info("Build using builder %r", builder.__class__.__name__)


### PR DESCRIPTION
In `Builder.create` https://github.com/ARPA-SIMC/moncic-ci/blob/e817e495ade43f7a4d2c1f1a316874c9cc555c34/moncic/build.py#L65-L67

`mypy` complains about missing parameters in `cls.builders["name"].create` because the `create` methods of the derived builders have a different signature.

```
moncic/build.py:67: error: Missing positional argument "srcdir" in call to "create" of "Builder"
moncic/build.py:67: error: Argument 1 to "create" of "Builder" has incompatible type "System"; expected "str"
moncic/build.py:67: error: Argument 2 to "create" of "Builder" has incompatible type "str"; expected "System"
```

I have renamed `Builder.create` to `Builder.create_builder`.