### PR TITLE
Fix incompatible type in BindConfig.create #68

### DIFF
--- a/moncic/distro.py
+++ b/moncic/distro.py
@@ -484,9 +484,9 @@ class DebianDistro(Distro):
                 "/var/cache/apt/archives",
                 "aptcache"))
 
-        if system.images.session.moncic.config.extra_packages_dir:
+        if (extra_packages_dir := system.images.session.extra_packages_dir()):
             config.binds.append(BindConfig.create(
-                system.images.session.extra_packages_dir(),
+                extra_packages_dir,
                 "/srv/moncic-ci/mirror/packages",
                 "aptpackages"))
 


### PR DESCRIPTION
`Session.config.config.extra_packages_dir` is tested for null twice. IIUC, the first one can be removed:

- https://github.com/ARPA-SIMC/moncic-ci/blob/aa93e3589a90604d9e591f01bc90e2b57b7447de/moncic/distro.py#L487-L491
- https://github.com/ARPA-SIMC/moncic-ci/blob/aa93e3589a90604d9e591f01bc90e2b57b7447de/moncic/session.py#L66-L74