### PR TITLE
ARPABuilder: copy patchfiles to SOURCES dir if they exist (fix #124)

### DIFF
--- a/moncic/operations/build_arpa.py
+++ b/moncic/operations/build_arpa.py
@@ -3,6 +3,7 @@ import shlex
 from pathlib import Path
 from typing import Any, override
 from glob import glob
+import shutil
 
 from moncic.container import Container
 from moncic.runner import UserConfig

--- a/moncic/operations/build_arpa.py
+++ b/moncic/operations/build_arpa.py
@@ -2,6 +2,7 @@ import logging
 import shlex
 from pathlib import Path
 from typing import Any, override
+from glob import glob
 
 from moncic.container import Container
 from moncic.runner import UserConfig

--- a/moncic/operations/build_arpa.py
+++ b/moncic/operations/build_arpa.py
@@ -147,10 +147,9 @@ class ARPABuilder(RPMBuilder):
             )
         else:
             # Convenzione SIMC per i repo con solo rpm
-            script.run_unquoted(
-                f"cp *.patch {guest_rpmbuild_sources_dir}/",
-                cwd=guest_rpmbuild_sources_dir,
-            )
+            for patchfile in glob.glob(f"{self.guest_source_path}/*.patch"):
+                shutil.copy(patchfile, guest_rpmbuild_sources_dir)
+
             script.run(["spectool", "-g", "-R", guest_specfile_path.as_posix()])
             script.run(["rpmbuild", "-ba", guest_specfile_path.as_posix()])
 


### PR DESCRIPTION
ARPABuilder: copy patchfiles to SOURCES dir if they exist (fix #124)